### PR TITLE
Fix #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+.Rbuildignore
+*.Rproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-.Rproj.user
-.Rhistory
-.RData
-.Ruserdata
-.Rbuildignore
-*.Rproj

--- a/R/assert_colnames.R
+++ b/R/assert_colnames.R
@@ -13,7 +13,7 @@
 #' assert_colnames(CO2, c("Plant","Type","Treatment","conc","uptake"))
 #' assert_colnames(CO2, c("Plant","Type"), only_colnames=FALSE)
 
-assert_colnames <- function(data, colnames, only_colnames=TRUE) {
+assert_colnames <- function(data, colnames, only_colnames=TRUE, quiet=FALSE) {
   # Do all specified colnames exist in dataframe?
     non_df_cols <- colnames[!colnames %in% colnames(data)]
   
@@ -32,5 +32,8 @@ assert_colnames <- function(data, colnames, only_colnames=TRUE) {
     stop(paste0("These columns exist in your dataframe but not in colnames: ",
                 paste(non_colname_cols, collapse=" ")))
   }
-  print("All column names present")
+    
+  if(!quiet) {
+    print("All column names present")
+  }
 }

--- a/R/assert_colnames.R
+++ b/R/assert_colnames.R
@@ -5,6 +5,7 @@
 #' @param data A data.frame or data.table
 #' @param colnames Character vector with column names corresponding to columns in \emph{data}
 #' @param only_colnames Assert that the only columns in the data object should be those in \emph{colnames}. Default = T.
+#' @param quiet Do you want to suppress the printed message when a test is passed? Default = F.
 
 #' @return Throws error if test is violated.
 #' @export

--- a/R/assert_nrows.R
+++ b/R/assert_nrows.R
@@ -10,7 +10,7 @@
 #' @examples
 #' assert_nrows(CO2,84)
 
-assert_nrows <- function(data,target_nrows) {
+assert_nrows <- function(data, target_nrows, quiet=FALSE) {
   if(nrow(data) != target_nrows) stop(paste0("Have ", nrow(data), " rows, expecting ",target_nrows))
-  print("All rows present")
+  if(!quiet) print("All rows present")
 }

--- a/R/assert_nrows.R
+++ b/R/assert_nrows.R
@@ -4,6 +4,7 @@
 
 #' @param data A data.frame or data.table
 #' @param target_nrows Numeric -- number of expected rows
+#' @param quiet Do you want to suppress the printed message when a test is passed? Default = F.
 
 #' @return Throws error if test is violated
 #' @export

--- a/man/assert_colnames.Rd
+++ b/man/assert_colnames.Rd
@@ -4,7 +4,7 @@
 \alias{assert_colnames}
 \title{Assert that a data.frame contains specified column names}
 \usage{
-assert_colnames(data, colnames, only_colnames = TRUE)
+assert_colnames(data, colnames, only_colnames = TRUE, quiet = FALSE)
 }
 \arguments{
 \item{data}{A data.frame or data.table}
@@ -12,6 +12,8 @@ assert_colnames(data, colnames, only_colnames = TRUE)
 \item{colnames}{Character vector with column names corresponding to columns in \emph{data}}
 
 \item{only_colnames}{Assert that the only columns in the data object should be those in \emph{colnames}. Default = T.}
+
+\item{quiet}{Do you want to suppress the printed message when a test is passed? Default = F.}
 }
 \value{
 Throws error if test is violated.

--- a/man/assert_nrows.Rd
+++ b/man/assert_nrows.Rd
@@ -4,12 +4,14 @@
 \alias{assert_nrows}
 \title{Assert that a data.frame contains a specified number of rows}
 \usage{
-assert_nrows(data, target_nrows)
+assert_nrows(data, target_nrows, quiet = FALSE)
 }
 \arguments{
 \item{data}{A data.frame or data.table}
 
 \item{target_nrows}{Numeric -- number of expected rows}
+
+\item{quiet}{Do you want to suppress the printed message when a test is passed? Default = F.}
 }
 \value{
 Throws error if test is violated


### PR DESCRIPTION
Add `quiet` parameter to `assert_colnames` and `assert_nrows` so users can suppress output.